### PR TITLE
Rsww 126 - reservation details shown in preferences

### DIFF
--- a/src/core/apiConfig.tsx
+++ b/src/core/apiConfig.tsx
@@ -83,9 +83,12 @@ export interface ReservationRequestPayload {
     price: number,
 
     roomReservationsIds: string[],
-    roomReservationsNames: string[],
     transportReservationsIds: string[],
     userId: string,
+
+    roomReservationsNames: string[],
+    locationNameFrom: string,
+    locationNameTo: string,
 }
 
 export interface PaymentPayload {

--- a/src/core/apiConfig.tsx
+++ b/src/core/apiConfig.tsx
@@ -93,8 +93,8 @@ export interface ReservationRequestPayload {
 
     hotelName: string,
     roomReservationsNames: string[],
-    locationNameFrom: string,
-    locationNameTo: string,
+    locationFromNameRegionAndCountry: string,
+    locationToNameRegionAndCountry: string,
     transportType: TransportType,
 }
 

--- a/src/core/apiConfig.tsx
+++ b/src/core/apiConfig.tsx
@@ -89,6 +89,7 @@ export interface ReservationRequestPayload {
     roomReservationsNames: string[],
     locationNameFrom: string,
     locationNameTo: string,
+    transportType: string,
 }
 
 export interface PaymentPayload {

--- a/src/core/apiConfig.tsx
+++ b/src/core/apiConfig.tsx
@@ -83,6 +83,7 @@ export interface ReservationRequestPayload {
     price: number,
 
     roomReservationsIds: string[],
+    roomReservationsNames: string[],
     transportReservationsIds: string[],
     userId: string,
 }

--- a/src/core/apiConfig.tsx
+++ b/src/core/apiConfig.tsx
@@ -70,6 +70,11 @@ export interface GetOfferDetailsParams {
     infants: number,
 }
 
+export enum TransportType {
+    Samolot = "Samolot",
+    Bus = "Bus"
+}
+
 export interface ReservationRequestPayload {
     id: string,
     hotelId: string,
@@ -90,7 +95,7 @@ export interface ReservationRequestPayload {
     roomReservationsNames: string[],
     locationNameFrom: string,
     locationNameTo: string,
-    transportType: string,
+    transportType: TransportType,
 }
 
 export interface PaymentPayload {

--- a/src/core/apiConfig.tsx
+++ b/src/core/apiConfig.tsx
@@ -86,6 +86,7 @@ export interface ReservationRequestPayload {
     transportReservationsIds: string[],
     userId: string,
 
+    hotelName: string,
     roomReservationsNames: string[],
     locationNameFrom: string,
     locationNameTo: string,

--- a/src/core/screens/Home.tsx
+++ b/src/core/screens/Home.tsx
@@ -1,5 +1,6 @@
 import SearchBar from "../../home/components/SearchBar";
 import {useNavigate} from "react-router-dom";
+import {useEffect} from "react";
 
 export default function Home () {
 
@@ -8,6 +9,19 @@ export default function Home () {
     const onSearch = () => {
         navigate('/offers');
     }
+
+    // work in progress - booking information
+    useEffect(() => {
+        const ws = new WebSocket(`ws://localhost:8086/reservations/ws/offerBooked`);
+
+        ws.onmessage = (event) => {
+            console.log("Received Booking message " + event.data);
+        }
+
+        return () => {
+            ws.close();
+        }
+    }, []);
 
     return(
         <div

--- a/src/core/screens/Home.tsx
+++ b/src/core/screens/Home.tsx
@@ -11,7 +11,6 @@ export default function Home () {
         navigate('/offers');
     }
 
-
     return(
         <div
             className='flex flex-col px-20 py-32 items-center homeContainer'

--- a/src/core/screens/Home.tsx
+++ b/src/core/screens/Home.tsx
@@ -11,18 +11,6 @@ export default function Home () {
         navigate('/offers');
     }
 
-    // work in progress - booking information
-    useEffect(() => {
-        const ws = new WebSocket(`ws://localhost:8086/reservations/ws/offerBooked`);
-
-        ws.onmessage = (event) => {
-            console.log("Received Booking message " + event.data);
-        }
-
-        return () => {
-            ws.close();
-        }
-    }, []);
 
     return(
         <div

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -58,6 +58,7 @@ const BuyOffer = () => {
             roomReservationsNames: selectedRooms.map(room => room.name),
             locationNameFrom: selectedTransport.transportCourse.departureFromLocation.region + ', Polska',
             locationNameTo: selectedTransport.transportCourse.arrivalAtLocation.region + ', ' + selectedTransport.transportCourse.arrivalAtLocation.country,
+            transportType: selectedTransport.transportCourse.type === 'PLANE' ? 'Samolot' : 'Bus',
         })
             .then(response => {
 

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -83,6 +83,19 @@ const BuyOffer = () => {
             });
     }
 
+    // work in progress - booking information
+    useEffect(() => {
+        const ws = new WebSocket(`ws://localhost:8082/reservations/ws/offerBooked`);
+
+        ws.onmessage = (event) => {
+            console.log("Received Booking message " + event.data);
+        }
+
+        return () => {
+            ws.close();
+        }
+    }, []);
+
     return (
         <div className='flex flex-col px-[32rem] py-24'>
             <p className='text-xl mb-6'>Szczegóły oferty</p>

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -6,6 +6,7 @@ import {ApiRequests} from "../../core/apiConfig";
 import {Button} from "@mui/material";
 import {Book, Bookmark, Bookmarks, CreditCard} from "@mui/icons-material";
 import {formatDate} from "../../core/utils";
+import { TransportType } from "../../core/apiConfig";
 
 const BuyOffer = () => {
 
@@ -60,7 +61,7 @@ const BuyOffer = () => {
             roomReservationsNames: selectedRooms.map(room => room.name),
             locationNameFrom: selectedTransport.transportCourse.departureFromLocation.region + ', Polska',
             locationNameTo: selectedTransport.transportCourse.arrivalAtLocation.region + ', ' + selectedTransport.transportCourse.arrivalAtLocation.country,
-            transportType: selectedTransport.transportCourse.type === 'PLANE' ? 'Samolot' : 'Bus',
+            transportType: selectedTransport.transportCourse.type === 'PLANE' ? TransportType.Samolot : TransportType.Bus,
         })
             .then(response => {
 

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -87,19 +87,6 @@ const BuyOffer = () => {
             });
     }
 
-    // work in progress - booking information
-    useEffect(() => {
-        const ws = new WebSocket(`ws://localhost:8082/reservations/ws/offerBooked`);
-
-        ws.onmessage = (event) => {
-            console.log("Received Booking message " + event.data);
-        }
-
-        return () => {
-            ws.close();
-        }
-    }, []);
-
     return (
         <div className='flex flex-col px-[32rem] py-24'>
             <p className='text-xl mb-6'>Szczegóły oferty</p>

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -53,6 +53,7 @@ const BuyOffer = () => {
             price: price,
 
             roomReservationsIds: selectedRooms.map(room => room.roomId),
+            roomReservationsNames: selectedRooms.map(room => room.name),
             transportReservationsIds: [selectedTransport.idTransport, selectedReturnTransport.idTransport],
             userId: crypto.randomUUID(),
         })

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -59,8 +59,8 @@ const BuyOffer = () => {
 
             hotelName: hotelName,
             roomReservationsNames: selectedRooms.map(room => room.name),
-            locationNameFrom: selectedTransport.transportCourse.departureFromLocation.region + ', Polska',
-            locationNameTo: selectedTransport.transportCourse.arrivalAtLocation.region + ', ' + selectedTransport.transportCourse.arrivalAtLocation.country,
+            locationFromNameRegionAndCountry: selectedTransport.transportCourse.departureFromLocation.region + ', Polska',
+            locationToNameRegionAndCountry: selectedTransport.transportCourse.arrivalAtLocation.region + ', ' + selectedTransport.transportCourse.arrivalAtLocation.country,
             transportType: selectedTransport.transportCourse.type === 'PLANE' ? TransportType.Samolot : TransportType.Bus,
         })
             .then(response => {

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -53,9 +53,11 @@ const BuyOffer = () => {
             price: price,
 
             roomReservationsIds: selectedRooms.map(room => room.roomId),
-            roomReservationsNames: selectedRooms.map(room => room.name),
             transportReservationsIds: [selectedTransport.idTransport, selectedReturnTransport.idTransport],
             userId: crypto.randomUUID(),
+            roomReservationsNames: selectedRooms.map(room => room.name),
+            locationNameFrom: selectedTransport.transportCourse.departureFromLocation.region + ', Polska',
+            locationNameTo: selectedTransport.transportCourse.arrivalAtLocation.region + ', ' + selectedTransport.transportCourse.arrivalAtLocation.country,
         })
             .then(response => {
 

--- a/src/offers/screens/BuyOffer.tsx
+++ b/src/offers/screens/BuyOffer.tsx
@@ -55,6 +55,8 @@ const BuyOffer = () => {
             roomReservationsIds: selectedRooms.map(room => room.roomId),
             transportReservationsIds: [selectedTransport.idTransport, selectedReturnTransport.idTransport],
             userId: crypto.randomUUID(),
+
+            hotelName: hotelName,
             roomReservationsNames: selectedRooms.map(room => room.name),
             locationNameFrom: selectedTransport.transportCourse.departureFromLocation.region + ', Polska',
             locationNameTo: selectedTransport.transportCourse.arrivalAtLocation.region + ', ' + selectedTransport.transportCourse.arrivalAtLocation.country,

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -18,7 +18,7 @@ const Preferences = () => {
     const [topTransportTypes, setTopTransportTypes] = useState<string[]>([]);
 
     useEffect(() => {
-        const ws = new WebSocket(`ws://localhost:8082/reservations/ws/offerBooked`);
+        const ws = new WebSocket(`ws://localhost:8082/reservations/ws/reservationPreferences`);
 
         ws.onmessage = (event) => {
             console.log("Received message: " + event.data);

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -1,7 +1,22 @@
 import {Paper} from "@mui/material";
+import React, {useEffect, useState} from "react";
 import {ConnectingAirports, Explore, Flight, Hotel, KingBed, MeetingRoom} from "@mui/icons-material";
 
 const Preferences = () => {
+
+    useEffect(() => {
+        const ws = new WebSocket(`ws://localhost:8082/reservations/ws/offerBooked`);
+
+        ws.onmessage = (event) => {
+            console.log("Received Booking message " + event.data);
+            // update user preferences
+        }
+
+        return () => {
+            ws.close();
+        }
+    }, []);
+
     return(
         <div className='flex flex-col px-64 py-24'>
             <div>
@@ -16,7 +31,7 @@ const Preferences = () => {
 
 
                     <ul className='flex flex-col gap-3'>
-                    <li>Malta</li>
+                        <li>Malta</li>
                         <li>Egipt</li>
                         <li>Maroko</li>
                     </ul>

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -81,7 +81,7 @@ const Preferences = () => {
         <div className='flex flex-col px-64 py-24'>
             <div className='grid grid-cols-2 grid-rows-2 gap-x-12 gap-y-8'>
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
-                    <h3 className='text-xl'>Top 3 kierunki podróży</h3>
+                    <h3 className='text-xl'>Popularne kierunki podróży</h3>
                     <ul className='flex flex-col gap-3'>
                         {topLocationNamesTo.map((location, index) => (
                             <li key={index}>{location}</li>
@@ -90,7 +90,7 @@ const Preferences = () => {
                 </Paper>
 
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
-                    <h3 className='text-xl'>Top 3 hotele</h3>
+                    <h3 className='text-xl'>Popularne hotele</h3>
                     <ul className='flex flex-col gap-3'>
                         {topHotels.map((hotel, index) => (
                             <li key={index}>{hotel}</li>
@@ -99,7 +99,7 @@ const Preferences = () => {
                 </Paper>
 
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
-                    <h3 className='text-xl'>Top 3 pokoje</h3>
+                    <h3 className='text-xl'>Popularne pokoje</h3>
                     <ul className='flex flex-col gap-3'>
                         {topRoomTypes.map((roomType, index) => (
                             <li key={index}>
@@ -111,7 +111,7 @@ const Preferences = () => {
                 </Paper>
 
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
-                    <h3 className='text-xl'>Top 3 typy transportu</h3>
+                    <h3 className='text-xl'>Popularne typy transportu</h3>
                     <ul className='flex flex-col gap-3'>
                         {topTransportTypes.map((transportType, index) => (
                             <li key={index}>{transportType}</li>

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -25,15 +25,15 @@ const Preferences = () => {
                 console.log("Received Booking message: " + event.data);
                 const hotelName = messageParts[0].split(': ')[2];
                 const roomNames = messageParts[1].split(': ')[1].replace(/[\[\]]/g, '').split(', ');
-                const locationFrom = messageParts[2].split(': ')[1];
-                const locationTo = messageParts[3].split(': ')[1];
+                const locationFromNameRegionAndCountry = messageParts[2].split(': ')[1];
+                const locationToNameRegionAndCountry = messageParts[3].split(': ')[1];
                 const transportType = messageParts[4].split(': ')[1];
     
                 const newReservation: Reservation = {
                     hotelName,
                     roomNames,
-                    locationFrom,
-                    locationTo,
+                    locationFrom: locationFromNameRegionAndCountry,
+                    locationTo: locationToNameRegionAndCountry,
                     transportType
                 };
     

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -8,6 +8,7 @@ type Reservation = {
     locationFromNameRegionAndCountry: string;
     locationToNameRegionAndCountry: string;
     transportType: string;
+    reservationTime: string;
 };
 
 const Preferences = () => {
@@ -35,21 +36,23 @@ const Preferences = () => {
                     const locationFromNameRegionAndCountry = messageParts[2].split(': ')[1];
                     const locationToNameRegionAndCountry = messageParts[3].split(': ')[1];
                     const transportType = messageParts[4].split(': ')[1];
-    
+                    const reservationTime = messageParts[5].split(': ')[1]; 
+
                     const newReservation = {
                         hotelName,
                         roomNames,
                         locationFromNameRegionAndCountry,
                         locationToNameRegionAndCountry,
-                        transportType
+                        transportType,
+                        reservationTime 
                     };
-    
+
                     setReservations(prevReservations => {
                         const updatedReservations = [newReservation, ...prevReservations];
                         return updatedReservations;
                     });
-                    
                     break;
+
                 case "TopHotels":
                     const topHotels = event.data.split(':')[1].split('#').map((item: string) => item.trim());
                     setTopHotels(topHotels);
@@ -119,12 +122,13 @@ const Preferences = () => {
                 </Paper>
     
                 <div className='mt-8 col-span-2'>
-                    <h2 className='text-xl font-bold mb-4'>Nowa rezerwacja</h2>
+                    <h2 className='text-xl font-bold mb-4'>Nowe rezerwacje</h2>
                     <Paper elevation={3}>
                         <TableContainer>
                             <Table>
                                 <TableHead>
                                     <TableRow>
+                                        <TableCell className='border border-gray-500 p-2'>Data i godzina</TableCell>
                                         <TableCell className='border border-gray-500 p-2'>Hotel</TableCell>
                                         <TableCell className='border border-gray-500 p-2'>Pokoje</TableCell>
                                         <TableCell className='border border-gray-500 p-2'>Skąd</TableCell>
@@ -135,6 +139,7 @@ const Preferences = () => {
                                 <TableBody>
                                     {reservations.map((reservation, index) => (
                                         <TableRow key={index}>
+                                            <TableCell className='border border-gray-500 p-2'>{reservation.reservationTime}</TableCell> 
                                             <TableCell className='border border-gray-500 p-2'>{reservation.hotelName}</TableCell>
                                             <TableCell className='border border-gray-500 p-2'>{reservation.roomNames.join(', ')}</TableCell>
                                             <TableCell className='border border-gray-500 p-2'>{reservation.locationFromNameRegionAndCountry}</TableCell>
@@ -144,6 +149,7 @@ const Preferences = () => {
                                     ))}
                                     {newReservations && (
                                         <TableRow>
+                                            <TableCell className='border border-gray-500 p-2'>{newReservations.reservationTime}</TableCell> 
                                             <TableCell className='border border-gray-500 p-2'>{newReservations.hotelName}</TableCell>
                                             <TableCell className='border border-gray-500 p-2'>{newReservations.roomNames.join(', ')}</TableCell>
                                             <TableCell className='border border-gray-500 p-2'>{newReservations.locationFromNameRegionAndCountry}</TableCell>

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -19,44 +19,35 @@ const Preferences = () => {
         const ws = new WebSocket(`ws://localhost:8082/reservations/ws/offerBooked`);
 
         ws.onmessage = (event) => {
-            console.log("Received Booking message: " + event.data);
-            // Parse the message
             const messageParts = event.data.split(' | ');
-            const hotelName = messageParts[0].split(': ')[2];
-            const roomNames = messageParts[1].split(': ')[1].replace(/[\[\]]/g, '').split(', ');
-            const locationFrom = messageParts[2].split(': ')[1];
-            const locationTo = messageParts[3].split(': ')[1];
-            const transportType = messageParts[4].split(': ')[1];
     
-            const newReservation: Reservation = {
-                hotelName,
-                roomNames,
-                locationFrom,
-                locationTo,
-                transportType
-            };
+            if (messageParts.length === 5) {
+                console.log("Received Booking message: " + event.data);
+                const hotelName = messageParts[0].split(': ')[2];
+                const roomNames = messageParts[1].split(': ')[1].replace(/[\[\]]/g, '').split(', ');
+                const locationFrom = messageParts[2].split(': ')[1];
+                const locationTo = messageParts[3].split(': ')[1];
+                const transportType = messageParts[4].split(': ')[1];
     
-            setReservations(prevReservations => {
-                const updatedReservations = [newReservation, ...prevReservations];
-                return updatedReservations.slice(0, 3); // Keep only the last 3 reservations
-            });
-        };
-
-        const closeWebSocket = () => {
-            if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.close();
+                const newReservation: Reservation = {
+                    hotelName,
+                    roomNames,
+                    locationFrom,
+                    locationTo,
+                    transportType
+                };
+    
+                setReservations(prevReservations => {
+                    const updatedReservations = [newReservation, ...prevReservations];
+                    return updatedReservations.slice(0, 3); // Keep only the last 3 reservations
+                });
+            } else {
+                console.log("Message was empty");
             }
         };
-
-        // Add event listener for page unload
-        window.addEventListener('beforeunload', closeWebSocket);
-
-        return () => {
-            // Cleanup on component unmount
-            closeWebSocket();
-            window.removeEventListener('beforeunload', closeWebSocket);
-        };
+    
     }, []);
+    
 
     return (
         <div className='flex flex-col px-64 py-24'>

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -46,6 +46,10 @@ const Preferences = () => {
             }
         };
     
+        return () => {
+            ws.close();
+            console.log("WebSocket connection closed");
+        };
     }, []);
     
 

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -58,7 +58,7 @@ const Preferences = () => {
                     setTopHotels(topHotels);
                     break;
                 case "TopRoomTypes":
-                    const topRoomTypes = event.data.split(':')[1].split('#').map((item: string) => item.trim());
+                    const topRoomTypes = event.data.split(':')[1].split('#').map((item: string) => item.replace(/[\[\]]/g, '').trim());
                     setTopRoomTypes(topRoomTypes);
                     break;
                 case "TopLocationNamesTo":

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -1,88 +1,111 @@
-import {Paper} from "@mui/material";
-import React, {useEffect, useState} from "react";
-import {ConnectingAirports, Explore, Flight, Hotel, KingBed, MeetingRoom} from "@mui/icons-material";
+import { Paper } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { ConnectingAirports, Explore, Hotel, MeetingRoom } from "@mui/icons-material";
+
+// Define the Reservation type
+type Reservation = {
+    hotelName: string;
+    roomNames: string[];
+    locationFrom: string;
+    locationTo: string;
+    transportType: string;
+};
 
 const Preferences = () => {
+    const [reservations, setReservations] = useState<Reservation[]>(() => {
+        // Load initial state from localStorage
+        const savedReservations = localStorage.getItem('reservations');
+        return savedReservations ? JSON.parse(savedReservations) : [];
+    });
 
     useEffect(() => {
         const ws = new WebSocket(`ws://localhost:8082/reservations/ws/offerBooked`);
 
         ws.onmessage = (event) => {
-            console.log("Received Booking message " + event.data);
-            // update user preferences
-        }
+            console.log("Received Booking message: " + event.data);
+            
+            // Parse the message
+            const messageParts = event.data.split(' | ');
+            
+            const hotelName = messageParts[0].split(': ')[2];
+            const roomNames = messageParts[1].split(': ')[1].replace(/[\[\]]/g, '').split(', ');
+            const locationFrom = messageParts[2].split(': ')[1];
+            const locationTo = messageParts[3].split(': ')[1];
+            const transportType = messageParts[4].split(': ')[1];
+
+            const newReservation: Reservation = {
+                hotelName,
+                roomNames,
+                locationFrom,
+                locationTo,
+                transportType
+            };
+
+            setReservations(prevReservations => {
+                const updatedReservations = [newReservation, ...prevReservations].slice(0, 3);
+                localStorage.setItem('reservations', JSON.stringify(updatedReservations)); // Save to localStorage
+                return updatedReservations;
+            });
+        };
 
         return () => {
             ws.close();
-        }
+        };
     }, []);
 
-    return(
+    return (
         <div className='flex flex-col px-64 py-24'>
-            <div>
-
-            </div>
             <div className='grid grid-cols-2 grid-rows-2 gap-x-12 gap-y-8'>
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
                     <div className='mb-5 flex flex-row gap-2 items-center'>
-                        <Explore style={{fontSize: 18}}/>
-                        <h3 className='text-xl'>Popularne kierunki podróży</h3>
+                        <Explore style={{fontSize: 18}} />
+                        <h3 className='text-xl'>Ostatnie kierunki podróży</h3>
                     </div>
-
-
                     <ul className='flex flex-col gap-3'>
-                        <li>Malta</li>
-                        <li>Egipt</li>
-                        <li>Maroko</li>
+                        {reservations.map((reservation, index) => (
+                            <li key={index}>{reservation.locationTo}</li>
+                        ))}
                     </ul>
                 </Paper>
 
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
                     <div className='mb-5 flex flex-row gap-2 items-center'>
-                        <Hotel style={{fontSize: 18}}/>
-                        <h3 className='text-xl'>Popularne hotele</h3>
+                        <Hotel style={{fontSize: 18}} />
+                        <h3 className='text-xl'>Ostatnie hotele</h3>
                     </div>
-
                     <ul className='flex flex-col gap-3'>
-                        <li>Grand Fafa Blue</li>
-                        <li>Great Fafa green</li>
-                        <li>Fuerteventura princess</li>
+                        {reservations.map((reservation, index) => (
+                            <li key={index}>{reservation.hotelName}</li>
+                        ))}
                     </ul>
                 </Paper>
 
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
                     <div className='mb-5 flex flex-row gap-2 items-center'>
-                        <MeetingRoom style={{fontSize: 18}}/>
-                        <h3 className='text-xl'>Popularne pokoje</h3>
+                        <MeetingRoom style={{fontSize: 18}} />
+                        <h3 className='text-xl'>Ostatnie pokoje</h3>
                     </div>
-
                     <ul className='flex flex-col gap-3'>
-                        <li>
-                            <p>Pokój 2-os z widokiem na góry</p>
-                            <p className='text-xs ml-4'>Fuerteventura princess</p>
-                        </li>
-                        <li>
-                            <p>Pokój 3-os z widokiem na morze</p>
-                            <p className='text-xs ml-4'>Fuerteventura princess</p>
-                        </li>
-                        <li>
-                            <p>Pokój 2-os z basenem</p>
-                            <p className='text-xs ml-4'>Grand Fafa Blue</p>
-                        </li>
+                        {reservations.flatMap((reservation, index) =>
+                            reservation.roomNames.map((roomName, roomIndex) => (
+                                <li key={`${index}-${roomIndex}`}>
+                                    <p>{roomName}</p>
+                                    <p className='text-xs ml-4'>{reservation.hotelName}</p>
+                                </li>
+                            ))
+                        )}
                     </ul>
-
-
                 </Paper>
 
                 <Paper elevation={2} className='flex flex-col justify-center items-center rounded-xl px-4 py-6'>
                     <div className='mb-5 flex flex-row gap-2 items-center'>
-                        <ConnectingAirports style={{fontSize: 18}}/>
-                        <h3 className='text-xl'>Popularne typy transportu</h3>
+                        <ConnectingAirports style={{fontSize: 18}} />
+                        <h3 className='text-xl'>Ostatnie typy transportu</h3>
                     </div>
-
                     <ul className='flex flex-col gap-3'>
-                        <li>Samolot</li>
-                        <li>Autobus</li>
+                        {reservations.map((reservation, index) => (
+                            <li key={index}>{reservation.transportType}</li>
+                        ))}
                     </ul>
                 </Paper>
             </div>

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -5,8 +5,8 @@ import { ConnectingAirports, Explore, Hotel, MeetingRoom } from "@mui/icons-mate
 type Reservation = {
     hotelName: string;
     roomNames: string[];
-    locationFrom: string;
-    locationTo: string;
+    locationFromNameRegionAndCountry: string;
+    locationToNameRegionAndCountry: string;
     transportType: string;
 };
 
@@ -31,8 +31,8 @@ const Preferences = () => {
                 const newReservation: Reservation = {
                     hotelName,
                     roomNames,
-                    locationFrom: locationFromNameRegionAndCountry,
-                    locationTo: locationToNameRegionAndCountry,
+                    locationFromNameRegionAndCountry: locationFromNameRegionAndCountry,
+                    locationToNameRegionAndCountry: locationToNameRegionAndCountry,
                     transportType
                 };
     
@@ -62,7 +62,7 @@ const Preferences = () => {
                     </div>
                     <ul className='flex flex-col gap-3'>
                         {reservations.map((reservation, index) => (
-                            <li key={index}>{reservation.locationTo}</li>
+                            <li key={index}>{reservation.locationToNameRegionAndCountry}</li>
                         ))}
                     </ul>
                 </Paper>

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -30,45 +30,44 @@ const Preferences = () => {
     
             switch (messageType) {
                 case "SingleReservation":
-                    const messageParts = event.data.split(' | ');
-                    const hotelName = messageParts[0].split(': ')[3];
-                    const roomNames = messageParts[1].split(': ')[1].replace(/[\[\]]/g, '').split(', ');
-                    const locationFromNameRegionAndCountry = messageParts[2].split(': ')[1];
-                    const locationToNameRegionAndCountry = messageParts[3].split(': ')[1];
-                    const transportType = messageParts[4].split(': ')[1];
-                    const reservationTime = messageParts[5].split(': ')[1]; 
-
+                    const reservationData = event.data.split(': ')[1];
+                    const reservation = JSON.parse(reservationData);
+    
                     const newReservation = {
-                        hotelName,
-                        roomNames,
-                        locationFromNameRegionAndCountry,
-                        locationToNameRegionAndCountry,
-                        transportType,
-                        reservationTime 
+                        hotelName: reservation.hotelName,
+                        roomNames: reservation.roomReservationsNames,
+                        locationFromNameRegionAndCountry: reservation.locationFromNameRegionAndCountry,
+                        locationToNameRegionAndCountry: reservation.locationToNameRegionAndCountry,
+                        transportType: reservation.transportType,
+                        reservationTime: reservation.reservationTime
                     };
-
+    
                     setReservations(prevReservations => {
                         const updatedReservations = [newReservation, ...prevReservations];
                         return updatedReservations;
                     });
                     break;
-
+    
                 case "TopHotels":
                     const topHotels = event.data.split(':')[1].split('#').map((item: string) => item.trim());
                     setTopHotels(topHotels);
                     break;
+    
                 case "TopRoomTypes":
                     const topRoomTypes = event.data.split(':')[1].split('#').map((item: string) => item.replace(/[\[\]]/g, '').trim());
                     setTopRoomTypes(topRoomTypes);
                     break;
+    
                 case "TopLocationNamesTo":
                     const topLocationNamesTo = event.data.split(':')[1].split('#').map((item: string) => item.trim());
                     setTopLocationNamesTo(topLocationNamesTo);
                     break;
+    
                 case "TopTransportTypes":
                     const topTransportTypes = event.data.split(':')[1].split('#').map((item: string) => item.trim());
                     setTopTransportTypes(topTransportTypes);
                     break;
+    
                 default:
                     console.log("Wrong type of message");
                     break;

--- a/src/preferences/screens/Preferences.tsx
+++ b/src/preferences/screens/Preferences.tsx
@@ -2,7 +2,6 @@ import { Paper } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { ConnectingAirports, Explore, Hotel, MeetingRoom } from "@mui/icons-material";
 
-// Define the Reservation type
 type Reservation = {
     hotelName: string;
     roomNames: string[];


### PR DESCRIPTION
Trzeba uruchmomić:
- rabbitmq
- wszystkie serwisy
- frontend


Przy rezerwacji oferty frontend wysyła do backendu informacje na temat zarezerwowanej oferty:
- nazwę hotelu
- nazwę lokacji wyjazdu
- nazwę lokacji przyjazdu
- nazwę pokoi
- nazwę typu transportu

Przy zapisywaniu rezerwacji w repozytorium (Saga), podstawowe informacje o rezerwacji są zapisywane w liście recentReservationRequests w klasie ReservationWebSocketHandlerBooking w każdej instacji reservation service

Jeśli dana instancja Reservation-service ma aktywną sesję webSocket’a z frontendem, to wysyła nowo zapisaną rezerwację do frontendu

Gdy strona z preferencjami jest odświeżana, frontend resetuje sesje webSocketa - reservation service przy tworzeniu nowego połączenia sprawdza czy ma zapisane jakieś rezerwacje (z poprzednich połączeń) i wysyła je do frontendu

Testowałem ten feature z włączonymi wszystkimi serwisami (dwie kopie Reservation service) + włączony rabbtimq + włączony frontend

PullRequest na backendzie: [link](https://github.com/Microarchitecturovisco/travel-api/pull/53)
